### PR TITLE
set an empty body when we don't have a body to forward

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,8 +102,13 @@ async fn handle_request(
             return Err(RequestError::NoPath { uri });
         }
     };
+    let body = if bytes.is_empty() {
+        None
+    } else {
+        Some(bytes)
+    };
     let raw_request = TwilightRequest {
-        body: Some(bytes),
+        body,
         form: None,
         headers: Some(headers),
         method,


### PR DESCRIPTION
Fixes "400 bad request" when we don't actually have a body to forward (like DELETE requests)