### PR TITLE
Fix compilation error with expose-metrics flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ async fn handle_request(
     trace!("Response: {:?}", resp);
 
     #[cfg(feature = "expose-metrics")]
-    timing!(METRIC_KEY, start, end, "method"=>m.to_string(), "route"=>p, "status"=>resp.status().to_string());
+    timing!(&METRIC_KEY[..], start, end, "method"=>m.to_string(), "route"=>p, "status"=>resp.status().to_string());
 
     debug!("{} {}: {}", m, p, resp.status());
 


### PR DESCRIPTION
When building the proxy with the expose-metrics flag, I ran into the following error:
```
$ cargo check --features=expose-metrics
    Checking twilight-http-proxy v0.1.0 (/home/ryan/rust/http-proxy-rxdn)
error[E0277]: the trait bound `Cow<'static, str>: From<METRIC_KEY>` is not satisfied
   --> src/main.rs:227:5
    |
227 |     timing!(METRIC_KEY, start, end, "method"=>m.to_string(), "route"=>p, "status"=>resp.status().to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<METRIC_KEY>` is not implemented for `Cow<'static, str>`
    |
   ::: /home/ryan/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-core-0.5.2/src/lib.rs:100:12
    |
100 |         N: Into<ScopedString>,
    |            ------------------ required by this bound in `Key::from_name_and_labels`
    |
    = help: the following implementations were found:
              <Cow<'a, CStr> as From<&'a CStr>>
              <Cow<'a, CStr> as From<&'a CString>>
              <Cow<'a, CStr> as From<CString>>
              <Cow<'a, OsStr> as From<&'a OsStr>>
            and 13 others
    = note: required because of the requirements on the impl of `Into<Cow<'static, str>>` for `METRIC_KEY`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `twilight-http-proxy`

To learn more, run the command again with --verbose.
```

Manually dereferencing the METRIC_KEY into a string slice seems to fix the issue - not sure why Rust isn't auto-derefencing the String for me. Running Rust stable 1.50, feel free to close if you can't repro on nightly etc