### PR TITLE
docs: Update twilight_http example, add alt docker build cmd with metrics enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,17 @@ HTTP client to see how to use it.
 this:
 
 ```rust
-use twilight_http::client::{
-    Proxy,
-    Client,
-};
+use twilight_http::Client;
 use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    let mut config = Client::builder();
-    config
-        .proxy(Proxy::all("http://localhost:3000")?)
-        .proxy_http(true)
-        .skip_ratelimiter(true);
-    let client = config.build()?;
+    let client = Client::builder()
+        .proxy("localhost:3000", true)
+        .ratelimiter(None)
+        .build();
+
+    Ok(())
 }
 ```
 
@@ -38,8 +35,11 @@ to listen via HTTPS, then don't use HTTP.
 Build the dockerfile and then run it:
 
 ```sh
-$ docker build . -t http-proxy
-$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 http-proxy
+docker build . -t http-proxy
+# Or build with the metrics feature enabled
+docker build . --build-arg FEATURES="expose-metrics" -t http-proxy
+
+docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 http-proxy
 ```
 
 This will set the discord token to `"my token"` and map the bound port to port

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This will set the discord token to `"my token"` and map the bound port to port
 3000 on the host machine.
 
 Images come in multiple different variants for metrics, ARM, Discord API v8 and
-v6. You can use these with their corresponding image tags found on
-[Docker Hub][docker-hub-tags].
+v6. You can use these with their corresponding image tags found on the
+[Docker Hub tags page][docker-hub-tags].
 
 ### Running via Cargo
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,20 @@ to listen via HTTPS, then don't use HTTP.
 
 ### Running via Docker
 
-Build the dockerfile and then run it:
+Prebuilt Docker images are published on [Docker Hub].
 
 ```sh
-$ docker build . -t http-proxy
-# Or build with the metrics feature enabled
-$ docker build . --build-arg FEATURES="expose-metrics" -t http-proxy
-
-$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 http-proxy
+$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 twilightrs/http-proxy
+# Or with metrics enabled
+$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 twilightrs/http-proxy:metrics
 ```
 
 This will set the discord token to `"my token"` and map the bound port to port
 3000 on the host machine.
+
+Images come in multiple different variants for metrics, ARM, Discord API v8 and
+v6. You can use these with their corresponding image tags found on
+[Docker Hub][docker-hub-tags].
 
 ### Running via Cargo
 
@@ -64,3 +66,5 @@ The exported histogram includes timing percentiles, response status codes, reque
 
 [twilight]: https://github.com/twilight-rs/twilight
 [`Net::HTTP`]: https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new
+[Docker Hub]: https://hub.docker.com/r/twilightrs/http-proxy
+[docker-hub-tags]: https://hub.docker.com/r/twilightrs/http-proxy/tags

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ to listen via HTTPS, then don't use HTTP.
 Build the dockerfile and then run it:
 
 ```sh
-docker build . -t http-proxy
+$ docker build . -t http-proxy
 # Or build with the metrics feature enabled
-docker build . --build-arg FEATURES="expose-metrics" -t http-proxy
+$ docker build . --build-arg FEATURES="expose-metrics" -t http-proxy
 
-docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 http-proxy
+$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 http-proxy
 ```
 
 This will set the discord token to `"my token"` and map the bound port to port


### PR DESCRIPTION
### Description

Updates the twilight_http example on the README.  Also adds a `docker build` command with metrics enabled. 

### Tested

Example now compiles on `twilight_http v0.3.5`