### PR TITLE
Support multiple tokens (+enhancements)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
 name = "twilight-http-proxy"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "http",
  "hyper",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,16 +930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,9 +1187,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twilight-http"
-version = "0.5.7"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a2518516b5ac7a2da957aa131e1f6ecf282d3718be85727b3095f714438eb7"
+checksum = "ec03fa6e8c7e3127239e536df797ea14a26bd7713960866e7d59c053ce171cd5"
 dependencies = [
  "hyper",
  "hyper-rustls",
@@ -1230,13 +1220,12 @@ dependencies = [
 
 [[package]]
 name = "twilight-model"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f3e738e706213e16d53c7faf76e5ea0a06f3d2ddc8221059bb1e52bda4568c"
+checksum = "6993d941e15df71b20c291d1e825be8f88ef8f884499bd237d6ea4436c26f8b9"
 dependencies = [
  "bitflags",
  "serde",
- "serde-value",
  "serde_repr",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,9 +449,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
@@ -1266,9 +1266,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1301,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1314,15 +1314,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
@@ -225,12 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,24 +238,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -272,21 +266,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-core",
@@ -383,9 +377,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -434,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -470,9 +464,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "lock_api"
@@ -542,20 +536,20 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0a7fa53d812d26e59d2baf7a6f77442041454ab32908eb304447f00f0dd4de"
+checksum = "a00f42f354a2ed4894db863b3a4db47aef2d2e4435b937221749bd37a8a7aaa8"
 dependencies = [
+ "ahash",
  "metrics-macros",
  "proc-macro-hack",
- "t1ha",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423ac561fc3300388e62947ce7f944ba6d40468afe9916ce5b7774171d8b38b8"
+checksum = "9db7052a7cb0b0c0922a1ce499c9e78576763b1d47499ba980a4fe731b96909d"
 dependencies = [
  "hyper",
  "ipnet",
@@ -583,10 +577,11 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c93306cf63ff153c57963151a011194af0f33c91fe30ec30faf98732350a1a"
+checksum = "a58e622a425b7308e73e4390c68b8cb3df4443f2a57495e391b978412531638c"
 dependencies = [
+ "ahash",
  "aho-corasick",
  "atomic-shim",
  "crossbeam-epoch 0.9.5",
@@ -601,7 +596,6 @@ dependencies = [
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
- "t1ha",
 ]
 
 [[package]]
@@ -681,9 +675,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "ordered-float"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
  "num-traits",
 ]
@@ -751,9 +745,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -834,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "9.0.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
+checksum = "1733f6f80c9c24268736a501cd00d41a9849b4faa7a9f9334c096e5d10553206"
 dependencies = [
  "bitflags",
 ]
@@ -892,15 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,25 +921,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -971,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -982,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -1030,31 +1000,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "snafu"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -1068,25 +1017,13 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "t1ha"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa44aa51ae1a544e2c35a38831ba54ae40591f21384816f531b84f3e984b9ccc"
-dependencies = [
- "cfg-if 0.1.10",
- "lazy_static",
- "num-traits",
- "rustc_version",
 ]
 
 [[package]]
@@ -1120,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1137,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1260,9 +1197,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twilight-http"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038fb8f7af4385d25020bacb42517cae0922017985dd2c60a1330720d76c6c33"
+checksum = "06a2518516b5ac7a2da957aa131e1f6ecf282d3718be85727b3095f714438eb7"
 dependencies = [
  "hyper",
  "hyper-rustls",
@@ -1283,7 +1220,6 @@ dependencies = [
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
- "snafu",
  "tokio",
  "tracing",
  "tracing-log",
@@ -1293,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-model"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7cad02f371543ac66dad15e3b5b5b8db3c150f68fd889f6135d8e240f5a3a1"
+checksum = "85f3e738e706213e16d53c7faf76e5ea0a06f3d2ddc8221059bb1e52bda4568c"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ name = "twilight-http-proxy"
 version = "0.1.0"
 
 [dependencies]
-twilight-http = { version = "0.5", default-features = false, features = ["rustls-webpki-roots"] }
-hyper = { version = "0.14", features = ["tcp", "server", "http1", "http2"] }
+dashmap = "4.0"
 http = "0.2"
+hyper = { version = "0.14", features = ["tcp", "server", "http1", "http2"] }
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
 tracing-log = "0.1"
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
+twilight-http = { version = "0.5", default-features = false, features = ["rustls-webpki-roots"] }
 
 # Only used by the `expose-metrics` feature.
 metrics = { version = "0.17", optional = true }
@@ -21,3 +22,9 @@ lazy_static = { version = "1.4", optional = true }
 [features]
 default = []
 expose-metrics = ["metrics", "metrics-exporter-prometheus", "lazy_static"]
+
+[profile.release]
+codegen-units = 1
+incremental = false
+lto = true
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
-twilight-http = { version = "0.5", default-features = false, features = ["rustls-webpki-roots"] }
+twilight-http = { version = "0.6.1", default-features = false, features = ["rustls-webpki-roots"] }
 
 # Only used by the `expose-metrics` feature.
 metrics = { version = "0.17", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ http = "0.2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
 tracing-log = "0.1"
-snafu = "0.6"
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
 
 # Only used by the `expose-metrics` feature.
-metrics = { version = "0.16", optional = true }
-metrics-exporter-prometheus = { version = "0.5", optional = true }
+metrics = { version = "0.17", optional = true }
+metrics-exporter-prometheus = { version = "0.6", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tracing = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
 twilight-http = { version = "0.5", default-features = false, features = ["rustls-webpki-roots"] }
+
 # Only used by the `expose-metrics` feature.
 metrics = { version = "0.17", optional = true }
 metrics-exporter-prometheus = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,23 +8,20 @@ version = "0.1.0"
 dashmap = "4.0"
 http = "0.2"
 hyper = { version = "0.14", features = ["tcp", "server", "http1", "http2"] }
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
 tracing-log = "0.1"
+tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
 twilight-http = { version = "0.5", default-features = false, features = ["rustls-webpki-roots"] }
-
 # Only used by the `expose-metrics` feature.
 metrics = { version = "0.17", optional = true }
 metrics-exporter-prometheus = { version = "0.6", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
 [features]
-default = []
 expose-metrics = ["metrics", "metrics-exporter-prometheus", "lazy_static"]
 
 [profile.release]
 codegen-units = 1
-incremental = false
 lto = true
-opt-level = 3
+panic = 'abort'

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ This will set the discord token to `"my token"` and bind to port 3000.
 
 You can configure the behaviour when using multiple tokens with these enviroment variables:
 
-* `CLIENT_DECAY_TIMEOUT` (defaults to 1 hour) sets the timeout after which a HTTP client (and associated ratelimit information) will be dropped due to not being used anymore
+* `CLIENT_DECAY_TIMEOUT` (in seconds; defaults to 1 hour) sets the timeout after which a HTTP client (and associated ratelimit information) will be dropped due to not being used anymore
 * `CLIENT_CACHE_MAX_SIZE` (defaults to no limit) limits the amount of HTTP clients in the cache - if full, the least recently used client will be removed
-* `CLIENT_REAP_INTERVAL` (defaults to 10 minutes) changes the interval at which clients will be checked for decay
+* `CLIENT_REAP_INTERVAL` (in seconds; defaults to 10 minutes) changes the interval at which clients will be checked for decay
 
 ## Grafana metrics
 The http proxy can expose grafana metrics when compiled with the ``expose-metrics`` feature. These metrics are then available on the ``/metrics`` endpoint.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This will use the running proxy, skip the ratelimiter (since the proxy does
 ratelimiting itself), and will request over HTTP. If your proxy is configured
 to listen via HTTPS, then don't use HTTP.
 
+By default, the proxy will use the token provided in the `DISCORD_TOKEN` enviroment variable for all requests. You can bypass this by providing a different token in the `Authorization` header yourself.
+
 ### Running via Docker
 
 Prebuilt Docker images are published on [Docker Hub].
@@ -57,6 +59,12 @@ $ DISCORD_TOKEN="my token" PORT=3000 ./target/release/twilight_http_proxy
 ```
 
 This will set the discord token to `"my token"` and bind to port 3000.
+
+You can configure the behaviour when using multiple tokens with these enviroment variables:
+
+* `CLIENT_DECAY_TIMEOUT` (defaults to 1 hour) sets the timeout after which a HTTP client (and associated ratelimit information) will be dropped due to not being used anymore
+* `CLIENT_CACHE_MAX_SIZE` (defaults to no limit) limits the amount of HTTP clients in the cache - if full, the least recently used client will be removed
+* `CLIENT_REAP_INTERVAL` (defaults to 10 minutes) changes the interval at which clients will be checked for decay
 
 ## Grafana metrics
 The http proxy can expose grafana metrics when compiled with the ``expose-metrics`` feature. These metrics are then available on the ``/metrics`` endpoint.

--- a/src/client_map.rs
+++ b/src/client_map.rs
@@ -1,0 +1,54 @@
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio::time::{interval, Duration, Instant};
+use twilight_http::Client;
+
+pub struct ClientMap {
+    default: Client,
+    inner: Arc<DashMap<String, (Client, Instant)>>,
+}
+
+async fn eliminate_old_clients(map: Arc<DashMap<String, (Client, Instant)>>) {
+    let one_hour = Duration::from_secs(3600);
+    let mut interval = interval(one_hour);
+    loop {
+        interval.tick().await;
+        let right_now = Instant::now();
+
+        map.retain(|_, (_, last_used)| *last_used + one_hour > right_now);
+    }
+}
+
+impl ClientMap {
+    pub fn new(default_client_token: String) -> Self {
+        let inner = Arc::new(DashMap::new());
+        let default = Client::new(default_client_token);
+
+        tokio::spawn(eliminate_old_clients(inner.clone()));
+
+        Self { default, inner }
+    }
+
+    pub fn get(&self, token: Option<&str>) -> Client {
+        if let Some(token) = token {
+            match self.default.token() {
+                Some(default_client_token) if default_client_token == token => self.default.clone(),
+                _ => {
+                    let access_time = Instant::now();
+                    let maybe_entry = self.inner.get_mut(token);
+                    if let Some(mut entry) = maybe_entry {
+                        entry.1 = access_time;
+                        entry.0.clone()
+                    } else {
+                        let client = Client::new(token);
+                        self.inner
+                            .insert(token.to_string(), (client.clone(), access_time));
+                        client
+                    }
+                }
+            }
+        } else {
+            self.default.clone()
+        }
+    }
+}

--- a/src/client_map.rs
+++ b/src/client_map.rs
@@ -1,32 +1,65 @@
 use dashmap::DashMap;
-use std::sync::Arc;
+use std::{env::var, sync::Arc};
 use tokio::time::{interval, Duration, Instant};
+use tracing::{debug, warn};
 use twilight_http::Client;
 
 pub struct ClientMap {
     default: Client,
+    max_size: Option<usize>,
     inner: Arc<DashMap<String, (Client, Instant)>>,
 }
 
 async fn eliminate_old_clients(map: Arc<DashMap<String, (Client, Instant)>>) {
-    let one_hour = Duration::from_secs(3600);
-    let mut interval = interval(one_hour);
+    let client_reap_interval =
+        Duration::from_secs(var("CLIENT_REAP_INTERVAL").map_or(600, |timeout| {
+            if let Ok(timeout_secs) = timeout.parse() {
+                timeout_secs
+            } else {
+                warn!("Unable to parse CLIENT_REAP_INTERVAL, proceeding with defaults");
+                600
+            }
+        }));
+    let client_decay_timeout =
+        Duration::from_secs(var("CLIENT_DECAY_TIEOUT").map_or(3600, |timeout| {
+            if let Ok(timeout_secs) = timeout.parse() {
+                timeout_secs
+            } else {
+                warn!("Unable to parse CLIENT_DECAY_TIMEOUT, proceeding with defaults");
+                3600
+            }
+        }));
+    let mut interval = interval(client_reap_interval);
     loop {
         interval.tick().await;
         let right_now = Instant::now();
 
-        map.retain(|_, (_, last_used)| *last_used + one_hour > right_now);
+        map.retain(|_, (_, last_used)| *last_used + client_decay_timeout > right_now);
+
+        debug!("Done reaping timed out HTTP clients");
     }
 }
 
 impl ClientMap {
     pub fn new(default_client_token: String) -> Self {
+        let max_size = var("CLIENT_CACHE_MAX_SIZE").map_or(None, |size| {
+            if let Ok(size) = size.parse() {
+                Some(size)
+            } else {
+                warn!("Unable to parse CLIENT_CACHE_MAX_SIZE, proceeding with defaults");
+                None
+            }
+        });
         let inner = Arc::new(DashMap::new());
         let default = Client::new(default_client_token);
 
         tokio::spawn(eliminate_old_clients(inner.clone()));
 
-        Self { default, inner }
+        Self {
+            default,
+            max_size,
+            inner,
+        }
     }
 
     pub fn get(&self, token: Option<&str>) -> Client {
@@ -40,6 +73,24 @@ impl ClientMap {
                         entry.1 = access_time;
                         entry.0.clone()
                     } else {
+                        if let Some(max_size) = self.max_size {
+                            if self.inner.len() >= max_size && max_size > 0 {
+                                let key = {
+                                    let first_entry = self.inner.iter().next().unwrap();
+                                    let oldest_entry =
+                                        self.inner.iter().fold(first_entry, |old, next| {
+                                            if old.1 > next.1 {
+                                                next
+                                            } else {
+                                                old
+                                            }
+                                        });
+                                    oldest_entry.key().to_string()
+                                };
+                                self.inner.remove(&key);
+                                debug!("Removed oldest entry from HTTP client cache");
+                            }
+                        }
                         let client = Client::new(token);
                         self.inner
                             .insert(token.to_string(), (client.clone(), access_time));

--- a/src/client_map.rs
+++ b/src/client_map.rs
@@ -91,7 +91,7 @@ impl ClientMap {
                                 debug!("Removed oldest entry from HTTP client cache");
                             }
                         }
-                        let client = Client::new(token);
+                        let client = Client::new(token.to_string());
                         self.inner
                             .insert(token.to_string(), (client.clone(), access_time));
                         client

--- a/src/client_map.rs
+++ b/src/client_map.rs
@@ -20,6 +20,7 @@ async fn reap_old_clients(map: Arc<DashMap<String, (Client, Instant)>>) {
                 600
             }
         }));
+
     let client_decay_timeout =
         Duration::from_secs(var("CLIENT_DECAY_TIEOUT").map_or(3600, |timeout| {
             if let Ok(timeout_secs) = timeout.parse() {
@@ -52,6 +53,7 @@ impl ClientMap {
                 None
             }
         });
+
         let inner = Arc::new(DashMap::new());
         let default = Client::new(default_client_token);
 
@@ -91,6 +93,7 @@ impl ClientMap {
 
                                     oldest_entry.key().to_string()
                                 };
+
                                 self.inner.remove(&key);
                                 debug!("Removed oldest entry from HTTP client cache");
                             }
@@ -99,6 +102,7 @@ impl ClientMap {
                         let client = Client::new(token.to_string());
                         self.inner
                             .insert(token.to_string(), (client.clone(), access_time));
+
                         client
                     }
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,54 @@
 use http::{Method, Uri};
 use hyper::Error as HyperError;
-use snafu::Snafu;
+use std::{error::Error, fmt};
 use twilight_http::{error::Error as TwilightError, routing::PathParseError};
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub(crate)))]
+#[derive(Debug)]
 pub enum RequestError {
     ChunkingRequest { source: HyperError },
     InvalidPath { source: PathParseError },
     InvalidMethod { method: Method },
     NoPath { uri: Uri },
     RequestIssue { source: TwilightError },
+}
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ChunkingRequest { source } => {
+                f.write_str("ChunkingRequest: ")?;
+                f.write_str(&source.to_string())?;
+            }
+            Self::InvalidPath { source } => {
+                f.write_str("InvalidPath: ")?;
+                f.write_str(&source.to_string())?;
+            }
+            Self::InvalidMethod { method } => {
+                f.write_str("InvalidMethod: ")?;
+                f.write_str(&method.to_string())?;
+            }
+            Self::NoPath { uri } => {
+                f.write_str("InvalidMethod: ")?;
+                f.write_str(&uri.to_string())?;
+            }
+            Self::RequestIssue { source } => {
+                f.write_str("RequestIssue: ")?;
+                f.write_str(&source.to_string())?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Error for RequestError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ChunkingRequest { source } => Some(source),
+            Self::InvalidPath { source, .. } => Some(source),
+            Self::InvalidMethod { .. } => None,
+            Self::NoPath { .. } => None,
+            Self::RequestIssue { source } => Some(source),
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,9 @@
-use http::{Method, Uri};
+use http::{Error as HttpError, Method, Uri};
 use hyper::Error as HyperError;
-use std::{error::Error, fmt};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result},
+};
 use twilight_http::{
     error::Error as TwilightError, response::DeserializeBodyError, routing::PathParseError,
 };
@@ -12,44 +15,42 @@ pub enum RequestError {
     InvalidPath { source: PathParseError },
     InvalidMethod { method: Method },
     NoPath { uri: Uri },
-    ResponseAssembly { source: http::Error },
+    ResponseAssembly { source: HttpError },
     RequestIssue { source: TwilightError },
 }
 
-impl fmt::Display for RequestError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for RequestError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             Self::ChunkingRequest { source } => {
                 f.write_str("ChunkingRequest: ")?;
-                f.write_str(&source.to_string())?;
+                source.fmt(f)
             }
             Self::DeserializeBody { source } => {
                 f.write_str("DeserializeBody: ")?;
-                f.write_str(&source.to_string())?;
+                source.fmt(f)
             }
             Self::InvalidPath { source } => {
                 f.write_str("InvalidPath: ")?;
-                f.write_str(&source.to_string())?;
+                source.fmt(f)
             }
             Self::InvalidMethod { method } => {
                 f.write_str("InvalidMethod: ")?;
-                f.write_str(&method.to_string())?;
+                method.fmt(f)
             }
             Self::NoPath { uri } => {
-                f.write_str("InvalidMethod: ")?;
-                f.write_str(&uri.to_string())?;
+                f.write_str("NoPath: ")?;
+                uri.fmt(f)
             }
             Self::ResponseAssembly { source } => {
                 f.write_str("ResponseAssembly: ")?;
-                f.write_str(&source.to_string())?;
+                source.fmt(f)
             }
             Self::RequestIssue { source } => {
                 f.write_str("RequestIssue: ")?;
-                f.write_str(&source.to_string())?;
+                source.fmt(f)
             }
         }
-
-        Ok(())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,47 +23,35 @@ impl Display for RequestError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::ChunkingRequest { source } => {
-                f.write_str("ChunkingRequest: ")?;
+                f.write_str("error when chunking request: ")?;
                 source.fmt(f)
             }
             Self::DeserializeBody { source } => {
-                f.write_str("DeserializeBody: ")?;
+                f.write_str("failed to deserialize body: ")?;
                 source.fmt(f)
             }
             Self::InvalidPath { source } => {
-                f.write_str("InvalidPath: ")?;
+                f.write_str("invalid path: ")?;
                 source.fmt(f)
             }
             Self::InvalidMethod { method } => {
-                f.write_str("InvalidMethod: ")?;
+                f.write_str("invalid method: ")?;
                 method.fmt(f)
             }
             Self::NoPath { uri } => {
-                f.write_str("NoPath: ")?;
+                f.write_str("no path in uri: ")?;
                 uri.fmt(f)
             }
             Self::ResponseAssembly { source } => {
-                f.write_str("ResponseAssembly: ")?;
+                f.write_str("error during response assembly: ")?;
                 source.fmt(f)
             }
             Self::RequestIssue { source } => {
-                f.write_str("RequestIssue: ")?;
+                f.write_str("error during request: ")?;
                 source.fmt(f)
             }
         }
     }
 }
 
-impl Error for RequestError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::ChunkingRequest { source } => Some(source),
-            Self::DeserializeBody { source } => Some(source),
-            Self::InvalidPath { source } => Some(source),
-            Self::InvalidMethod { .. } => None,
-            Self::NoPath { .. } => None,
-            Self::ResponseAssembly { source } => Some(source),
-            Self::RequestIssue { source } => Some(source),
-        }
-    }
-}
+impl Error for RequestError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,7 @@ impl Error for RequestError {
         match self {
             Self::ChunkingRequest { source } => Some(source),
             Self::DeserializeBody { source } => Some(source),
-            Self::InvalidPath { source, .. } => Some(source),
+            Self::InvalidPath { source } => Some(source),
             Self::InvalidMethod { .. } => None,
             Self::NoPath { .. } => None,
             Self::ResponseAssembly { source } => Some(source),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,18 @@
 use http::{Method, Uri};
 use hyper::Error as HyperError;
 use std::{error::Error, fmt};
-use twilight_http::{error::Error as TwilightError, routing::PathParseError};
+use twilight_http::{
+    error::Error as TwilightError, response::DeserializeBodyError, routing::PathParseError,
+};
 
 #[derive(Debug)]
 pub enum RequestError {
     ChunkingRequest { source: HyperError },
+    DeserializeBody { source: DeserializeBodyError },
     InvalidPath { source: PathParseError },
     InvalidMethod { method: Method },
     NoPath { uri: Uri },
+    ResponseAssembly { source: http::Error },
     RequestIssue { source: TwilightError },
 }
 
@@ -17,6 +21,10 @@ impl fmt::Display for RequestError {
         match self {
             Self::ChunkingRequest { source } => {
                 f.write_str("ChunkingRequest: ")?;
+                f.write_str(&source.to_string())?;
+            }
+            Self::DeserializeBody { source } => {
+                f.write_str("DeserializeBody: ")?;
                 f.write_str(&source.to_string())?;
             }
             Self::InvalidPath { source } => {
@@ -30,6 +38,10 @@ impl fmt::Display for RequestError {
             Self::NoPath { uri } => {
                 f.write_str("InvalidMethod: ")?;
                 f.write_str(&uri.to_string())?;
+            }
+            Self::ResponseAssembly { source } => {
+                f.write_str("ResponseAssembly: ")?;
+                f.write_str(&source.to_string())?;
             }
             Self::RequestIssue { source } => {
                 f.write_str("RequestIssue: ")?;
@@ -45,9 +57,11 @@ impl Error for RequestError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::ChunkingRequest { source } => Some(source),
+            Self::DeserializeBody { source } => Some(source),
             Self::InvalidPath { source, .. } => Some(source),
             Self::InvalidMethod { .. } => None,
             Self::NoPath { .. } => None,
+            Self::ResponseAssembly { source } => Some(source),
             Self::RequestIssue { source } => Some(source),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use twilight_http::{
     error::Error as TwilightError, response::DeserializeBodyError, routing::PathParseError,
 };
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub enum RequestError {
     ChunkingRequest { source: HyperError },

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use http::{Error as HttpError, Method, Uri};
 use hyper::Error as HyperError;
 use std::{
     error::Error,
-    fmt::{Display, Formatter, Result},
+    fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_http::{
     error::Error as TwilightError, response::DeserializeBodyError, routing::PathParseError,
@@ -20,7 +20,7 @@ pub enum RequestError {
 }
 
 impl Display for RequestError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::ChunkingRequest { source } => {
                 f.write_str("ChunkingRequest: ")?;


### PR DESCRIPTION
This does these things:
1. Removes snafu as a dependency
2. Updates metrics dependencies
3. Adds release profile optimizations for smaller size and better performance
4. Allows the use of multiple tokens by using a map of tokens to clients internally, creating new ones as needed and removing unused clients (those not used in the last hour) once per 10mins (optionally customizable via `CLIENT_DECAY_TIMEOUT`, `CLIENT_CACHE_MAX_SIZE`, `CLIENT_REAP_INTERVAL`)