### PR TITLE
refactor: use tracing_subscriber directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,7 +1213,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "tokio",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "twilight-http",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["tcp", "server", "http1", "http2"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
-tracing-log = "0.1"
-tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }
+tracing-subscriber = "0.2"
 twilight-http = { version = "0.6.1", default-features = false, features = ["rustls-webpki-roots"] }
 
 # Only used by the `expose-metrics` feature.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,7 @@ use std::{
     sync::Arc,
 };
 use tracing::{debug, error, info, trace};
-use tracing_log::LogTracer;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::EnvFilter;
 use twilight_http::{
     client::Client,
     request::{Method, RequestBuilder},
@@ -45,17 +44,11 @@ lazy_static! {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    LogTracer::init()?;
-
-    let log_filter_layer =
-        EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
-    let log_fmt_layer = fmt::layer();
-
-    let log_subscriber = tracing_subscriber::registry()
-        .with(log_filter_layer)
-        .with(log_fmt_layer);
-
-    tracing::subscriber::set_global_default(log_subscriber)?;
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
 
     let host_raw = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".into());
     let host = IpAddr::from_str(&host_raw)?;


### PR DESCRIPTION
`tracing-log` can be removed since `tracing-subscriber` logs "log" events by default. Also removes explicitly depending on default features of `tracing-subscriber`