### PR TITLE
feat: graceful shutdown with signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,7 +1066,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ dashmap = "4.0"
 http = "0.2"
 hyper = { version = "0.14", features = ["tcp", "server", "client", "http1", "http2"] }
 hyper-rustls = { version = "0.22", default-features = false, features = ["webpki-tokio"] }
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "signal"] }
 tracing = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.2", features = ["fmt", "registry"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@
 ARG RUST_TARGET="x86_64-unknown-linux-musl"
 # Musl target, either x86_64-linux-musl, aarch64-linux-musl, arm-linux-musleabi, etc.
 ARG MUSL_TARGET="x86_64-linux-musl"
-# Final architecture used by Alpine
-# Uses Kernel Naming (aarch64, armv7, x86_64, s390x, ppc64le)
-ARG FINAL_TARGET="x86_64"
 # The crate features to build this with
 ARG FEATURES=""
 
@@ -74,21 +71,8 @@ RUN source $HOME/.cargo/env && \
     cp target/$RUST_TARGET/release/twilight-http-proxy /twilight-http-proxy && \
     actual-strip /twilight-http-proxy
 
-FROM docker.io/library/alpine:edge AS dumb-init
-ARG FINAL_TARGET
-
-RUN apk update && \
-    VERSION=$(apk search dumb-init) && \
-    mkdir out && \
-    cd out && \
-    wget "https://dl-cdn.alpinelinux.org/alpine/edge/community/$FINAL_TARGET/$VERSION.apk" -O dumb-init.apk && \
-    tar xf dumb-init.apk && \
-    mv usr/bin/dumb-init /dumb-init
-
 FROM scratch
 
-COPY --from=dumb-init /dumb-init /dumb-init
 COPY --from=build /twilight-http-proxy /twilight-http-proxy
 
-ENTRYPOINT ["./dumb-init", "--"]
 CMD ["./twilight-http-proxy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ use twilight_http::{
     routing::Path,
 };
 
+#[cfg(unix)]
+use tokio::signal::unix::{signal, SignalKind};
+
 #[cfg(feature = "expose-metrics")]
 use std::{future::Future, pin::Pin, time::Instant};
 
@@ -121,13 +124,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let server = Server::bind(&address).serve(service);
 
+    let graceful = server.with_graceful_shutdown(shutdown_signal());
+
     info!("Listening on http://{}", address);
 
-    if let Err(why) = server.await {
+    if let Err(why) = graceful.await {
         error!("Fatal server error: {}", why);
     }
 
     Ok(())
+}
+
+#[cfg(windows)]
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install CTRL+C signal handler");
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    let mut sigint = signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+
+    tokio::select! {
+        _ = sigint.recv() => {},
+        _ = sigterm.recv() => {},
+    };
 }
 
 fn path_name(path: &Path) -> &'static str {


### PR DESCRIPTION
This adds a graceful shutdown handler to the server, waiting for a platform-dependent signal before terminating. On Windows, this is CTRL+C, on Unix SIGINT or SIGTERM. This is mainly to remove the dependency on dumb-init for signal forwarding in the Docker image.