### PR TITLE
Add metrics if the response is a non-200 status

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,13 +262,9 @@ async fn handle_request(
         Ok(resp) => resp,
         Err(e) => {
             #[cfg(feature = "expose-metrics")]
-            if let TwilightErrorType::Response {
-                body: _,
-                error: _,
-                status,
-            } = e.kind()
-            {
+            if let TwilightErrorType::Response { status, .. } = e.kind() {
                 let end = Instant::now();
+
                 histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string());
             }
             error!("Failed to receive reply body: {:?}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,7 +265,13 @@ async fn handle_request(
             if let TwilightErrorType::Response { status, .. } = e.kind() {
                 let end = Instant::now();
 
-                histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string());
+                histogram!(
+                    METRIC_KEY.as_str(),
+                    end - start,
+                    "method"=>m.to_string(),
+                    "route"=>p,
+                    "status"=>status.to_string(),
+                );
             }
             error!("Failed to receive reply body: {:?}", e);
             return Err(RequestError::RequestIssue { source: e });
@@ -279,7 +285,13 @@ async fn handle_request(
 
     let status = resp.status();
     #[cfg(feature = "expose-metrics")]
-    histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string());
+    histogram!(
+        METRIC_KEY.as_str(),
+        end - start,
+        "method"=>m.to_string(),
+        "route"=>p,
+        "status"=>status.to_string(),
+    );
 
     let mut response_builder =
         Response::builder().status(StatusCode::from_u16(status.raw()).unwrap());


### PR DESCRIPTION
This adds back non-200 status codes to metrics as they were being eaten by a short-cutting return