### PR TITLE
performance: remove arc clone & alloc for each request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f4087b5a1164f92255f8b301c88fc8627e5abf5e25b5476f84b02e4b47795d"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c36c619c422113552db4eb28cddba8faa757e33f758cc3415bd2885977b591"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1225,7 @@ dependencies = [
 name = "twilight-http-proxy"
 version = "0.1.0"
 dependencies = [
+ "const_format",
  "dashmap",
  "http",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ name = "twilight-http-proxy"
 version = "0.1.0"
 
 [dependencies]
+const_format = "0.2"
 dashmap = "4.0"
 http = "0.2"
 hyper = { version = "0.14", features = ["tcp", "server", "http1", "http2"] }


### PR DESCRIPTION
Benchmarked with [`hey`](https://github.com/rakyll/hey) `-n 100000 -c 100 http://127.0.0.1:8080` (running with `RUST_LOG=off`) I was able to reach ~50,000 requests/s.

Switching to `Box::leak` netted me ~52,000 requests/s (4%+).

Switching to concatcp (no alloc on requests) netted me ~51,000 requests/s (2%+).

Enabling both reached ~55,000 requests/s (10%+).

The benchmark methodology was super bad (just running hey a few times and in my head averaging it) but the results are obvious enough that real benchmarking should show them too