### PR TITLE
expose rate limit scope in metrics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -362,12 +362,15 @@ async fn handle_request(
 
     let status = resp.status();
     #[cfg(feature = "expose-metrics")]
-        {
-            let scope = resp.headers().get("X-RateLimit-Scope")
-                .map(|header| header.to_str().unwrap_or("")).unwrap_or("")
-                .to_string();
-            histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string(), "scope" => scope);
-        }
+    {
+        let scope = resp
+            .headers()
+            .get("X-RateLimit-Scope")
+            .map(|header| header.to_str().unwrap_or(""))
+            .unwrap_or("")
+            .to_string();
+        histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string(), "scope" => scope);
+    }
 
     debug!("{} {} ({}): {}", m, p, request_path, status);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,12 @@ async fn handle_request(
 
     let status = resp.status();
     #[cfg(feature = "expose-metrics")]
-    histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string());
+        {
+            let scope = resp.headers().get("X-RateLimit-Scope")
+                .map(|header| header.to_str().unwrap_or("")).unwrap_or("")
+                .to_string();
+            histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string(), "scope" => scope);
+        }
 
     debug!("{} {} ({}): {}", m, p, request_path, status);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ async fn handle_request(
         let scope = resp
             .headers()
             .get("X-RateLimit-Scope")
-            .map(|header| header.to_str().unwrap_or(""))
+            .and_then(|header| header.to_str().ok())
             .unwrap_or("")
             .to_string();
         histogram!(METRIC_KEY.as_str(), end - start, "method"=>m.to_string(), "route"=>p, "status"=>status.to_string(), "scope" => scope);


### PR DESCRIPTION
exposes the rate limit scopes in the metrics. this allows for separating what rate limit responses could/should have been avoided, from the "unavoidable" ones on shared resources