### PR TITLE
Redo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,32 @@
 `http-proxy` is a ratelimited HTTP proxy in front of the Discord API, making use
 of [twilight].
 
-### Using it
+## Using it
 
-HTTP clients often support proxies, such as Ruby's [`Net::HTTP`]. Read into your
-HTTP client to see how to use it.
+This proxy is not a "real" HTTP `CONNECT` TCP proxy, instead it mocks to be the
+Discord API.
 
-`twilight_http` natively supports using `twilight_http_proxy`, so you can use it like
+In order to use it, change the base URL of all your routes from
+`https://discord.com/api/v9` to `http://localhost:3000/api/v9`. The proxy
+actively supports routes from API v9, but will also try to request the
+corresponding routes on older API versions if you so request in the URL.
+
+A very naive example of using the proxy with cURL would look like this:
+
+```bash
+# Previously
+$ curl https://discord.com/api/v9/users/@me
+# With the proxy
+$ curl http://localhost:3000/api/v9/users/@me
+
+# Or other API versions
+$ curl http://localhost:3000/users/@me
+$ curl http://localhost:3000/api/users/@me
+$ curl http://localhost:3000/api/v8/users/@me
+```
+
+`twilight_http` natively supports using `twilight_http_proxy`, so you can use
+it like
 this:
 
 ```rust
@@ -27,10 +47,32 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 ```
 
 This will use the running proxy, skip the ratelimiter (since the proxy does
-ratelimiting itself), and will request over HTTP. If your proxy is configured
-to listen via HTTPS, then don't use HTTP.
+ratelimiting itself), and will request over HTTP.
 
-By default, the proxy will use the token provided in the `DISCORD_TOKEN` enviroment variable for all requests. You can bypass this by providing a different token in the `Authorization` header yourself.
+If you are using a different Discord API client, make sure that you are not
+ratelimiting outgoing requests, because the proxy will do this instead. Very
+short HTTP client timeouts may also cause issues with longer ratelimits.
+
+### Multiple applications
+
+By default, the proxy will use the token provided in the `DISCORD_TOKEN`
+enviroment variable for all requests. You can bypass this by providing a
+different token in the `Authorization` header yourself.
+
+The proxy will keep track of ratelimits on a per-token basis, so using multiple
+applications is as easy as sending the header alongside your requests.
+
+You can configure how long the proxy stores ratelimit information with these
+enviroment variables:
+
+- `CLIENT_DECAY_TIMEOUT` (in seconds; defaults to 1 hour) sets the timeout
+  after which ratelimiting information will be dropped due to not being used
+  anymore
+- `CLIENT_CACHE_MAX_SIZE` (defaults to no limit) limits the amount of
+  ratelimiting information in the cache - if full, the least recently used
+  ratelimiting information will be removed
+- `CLIENT_REAP_INTERVAL` (in seconds; defaults to 10 minutes) changes the
+  interval at which ratelimiting information will be checked for decay
 
 ### Running via Docker
 
@@ -39,15 +81,16 @@ Prebuilt Docker images are published on [Docker Hub].
 ```sh
 $ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 twilightrs/http-proxy
 # Or with metrics enabled
-$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 twilightrs/http-proxy:metrics
+$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80
+twilightrs/http-proxy:metrics
 ```
 
 This will set the discord token to `"my token"` and map the bound port to port
 3000 on the host machine.
 
-Images come in multiple different variants for metrics, ARM, Discord API v8 and
-v6. You can use these with their corresponding image tags found on the
-[Docker Hub tags page][docker-hub-tags].
+Images come in multiple different variants for metrics and supported
+architectures. You can use these with their corresponding image tags found on
+the [Docker Hub tags page][docker-hub-tags].
 
 ### Running via Cargo
 
@@ -60,21 +103,36 @@ $ DISCORD_TOKEN="my token" PORT=3000 ./target/release/twilight_http_proxy
 
 This will set the discord token to `"my token"` and bind to port 3000.
 
-You can configure the behaviour when using multiple tokens with these enviroment variables:
+### Additional configuration
 
-* `CLIENT_DECAY_TIMEOUT` (in seconds; defaults to 1 hour) sets the timeout after which a HTTP client (and associated ratelimit information) will be dropped due to not being used anymore
-* `CLIENT_CACHE_MAX_SIZE` (defaults to no limit) limits the amount of HTTP clients in the cache - if full, the least recently used client will be removed
-* `CLIENT_REAP_INTERVAL` (in seconds; defaults to 10 minutes) changes the interval at which clients will be checked for decay
+HTTP2 may cause issues with high concurrency (i.e. many concurrent requests).
+If you encounter frequent error logs related to this, force the use of HTTP1 by
+setting `DISABLE_HTTP2` to any value when running the proxy.
 
-HTTP2 may cause issues with high concurrency (i.e. many concurrent requests). If you encounter frequent error logs related to this, force the use of HTTP1 by setting `DISABLE_HTTP2` to any value when running the proxy.
+## Prometheus metrics
 
-## Grafana metrics
-The http proxy can expose grafana metrics when compiled with the ``expose-metrics`` feature. These metrics are then available on the ``/metrics`` endpoint.
-You can set the metrics key used for the histogram data by setting the ``METRIC_KEY`` environment variable.
+The HTTP proxy can expose prometheus metrics when compiled with the
+`expose-metrics` feature. These metrics are then available on the `/metrics`
+endpoint.
+You can set the metrics key used for the histogram data by setting the
+`METRIC_KEY` environment variable.
 
-The exported histogram includes timing percentiles, response status codes, request path and request method. Calls to the metrics endpoint itself are not included in the metrics.
+The exported histogram includes timing percentiles, response status codes,
+request path and request method. Calls to the metrics endpoint itself are not
+included in the metrics.
+
+## Error behaviour
+
+If processing an incoming request fails, the proxy will respond with a 5xx
+status code and a helpful error message in the response body. Currently, these
+status codes include:
+
+- `500` if the proxy generates an invalid URI or the ratelimiter fails
+  internally
+- `501` if the client requested an unsupported API path or used an unsupported
+  HTTP method
+- `502` if the request made by the proxy fails
 
 [twilight]: https://github.com/twilight-rs/twilight
-[`Net::HTTP`]: https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new
-[Docker Hub]: https://hub.docker.com/r/twilightrs/http-proxy
+[docker hub]: https://hub.docker.com/r/twilightrs/http-proxy
 [docker-hub-tags]: https://hub.docker.com/r/twilightrs/http-proxy/tags

--- a/README.md
+++ b/README.md
@@ -3,23 +3,19 @@
 `http-proxy` is a ratelimited HTTP proxy in front of the Discord API, making use
 of [twilight].
 
-## Using it
+## Use
 
-This proxy is not a "real" HTTP `CONNECT` TCP proxy, instead it mocks to be the
+This proxy is not a "real" HTTP `CONNECT` TCP proxy, it instead mocks the
 Discord API.
 
-In order to use it, change the base URL of all your routes from
-`https://discord.com/api/v9` to `http://localhost:3000/api/v9`. The proxy
-actively supports routes from API v9, but will also try to request the
-corresponding routes on older API versions if you so request in the URL.
-
-A very naive example of using the proxy with cURL would look like this:
+Using it is as easy as changing the base of all routes from `discord.com` to
+`localhost:3000`, like so:
 
 ```bash
 # Previously
-$ curl https://discord.com/api/v9/users/@me
+$ curl https://discord.com/api/users/@me
 # With the proxy
-$ curl http://localhost:3000/api/v9/users/@me
+$ curl http://localhost:3000/api/users/@me
 
 # Or other API versions
 $ curl http://localhost:3000/users/@me
@@ -27,9 +23,12 @@ $ curl http://localhost:3000/api/users/@me
 $ curl http://localhost:3000/api/v8/users/@me
 ```
 
+The proxy actively supports routes from API v9, but will also try to request
+the corresponding routes on older or newer API versions if you so request in
+the URL.
+
 `twilight_http` natively supports using `twilight_http_proxy`, so you can use
-it like
-this:
+it like this:
 
 ```rust
 use twilight_http::Client;
@@ -81,8 +80,7 @@ Prebuilt Docker images are published on [Docker Hub].
 ```sh
 $ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 twilightrs/http-proxy
 # Or with metrics enabled
-$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80
-twilightrs/http-proxy:metrics
+$ docker run -itd -e DISCORD_TOKEN="my token" -p 3000:80 twilightrs/http-proxy:metrics
 ```
 
 This will set the discord token to `"my token"` and map the bound port to port


### PR DESCRIPTION
Entire revamp of the documentation as explained in the linked issue.

[Rendered](https://github.com/Gelbpunkt/http-proxy/blob/redo-documentation/README.md)

Closes #45 