### PR TITLE
fix: insert ratelimiter in map when max_size is not specified

### DIFF
--- a/src/ratelimiter_map.rs
+++ b/src/ratelimiter_map.rs
@@ -116,7 +116,7 @@ impl RatelimiterMap {
 
                     let ratelimiter = InMemoryRatelimiter::new();
 
-                    if self.max_size.filter(|max| max != &0).is_some() {
+                    if self.max_size.is_none() || self.max_size.filter(|max| max != &0).is_some() {
                         self.inner
                             .insert(token.to_string(), (ratelimiter.clone(), access_time));
                     }

--- a/src/ratelimiter_map.rs
+++ b/src/ratelimiter_map.rs
@@ -116,7 +116,7 @@ impl RatelimiterMap {
 
                     let ratelimiter = InMemoryRatelimiter::new();
 
-                    if self.max_size.is_none() || self.max_size.filter(|max| max != &0).is_some() {
+                    if self.max_size.map_or(true, |max| max != &0) {
                         self.inner
                             .insert(token.to_string(), (ratelimiter.clone(), access_time));
                     }

--- a/src/ratelimiter_map.rs
+++ b/src/ratelimiter_map.rs
@@ -116,7 +116,7 @@ impl RatelimiterMap {
 
                     let ratelimiter = InMemoryRatelimiter::new();
 
-                    if self.max_size.map_or(true, |max| max != &0) {
+                    if self.max_size.map_or(true, |max| max != 0) {
                         self.inner
                             .insert(token.to_string(), (ratelimiter.clone(), access_time));
                     }


### PR DESCRIPTION
According to the README, the default value for `CLIENT_CACHE_MAX_SIZE` is no limit. This implies that the ratelimiter must be inserted into the dash map when `max_size` is not specified.

The current issue is that, when `CLIENT_CACHE_MAX_SIZE` is not specified & a token other than the default token is used, the ratelimiter never gets inserted into the dashmap (a new one is created for each request but never inserted into the map), causing it to not handle ratelimits at all.