### PR TITLE
add idle timeout for metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +109,12 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
@@ -491,14 +506,18 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d24dc2dbae22bff6f1f9326ffce828c9f07ef9cc1e8002e5279f845432a30a"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown",
+ "indexmap",
  "metrics",
  "num_cpus",
+ "ordered-float",
  "parking_lot",
  "portable-atomic",
  "quanta",
+ "radix_trie",
  "sketches-ddsketch",
 ]
 
@@ -515,6 +534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +550,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -539,6 +576,15 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "overload"
@@ -631,6 +677,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1041,6 +1097,7 @@ dependencies = [
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
+ "metrics-util",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ twilight-http-ratelimiting = "0.13"
 # Only used by the `expose-metrics` feature.
 metrics = { version = "0.20", optional = true }
 metrics-exporter-prometheus = { version = "0.11", default-features = false, optional = true }
+metrics-util = { version = "0.14", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
 [features]
-expose-metrics = ["metrics", "metrics-exporter-prometheus", "lazy_static"]
+expose-metrics = ["metrics", "metrics-exporter-prometheus", "metrics-util", "lazy_static"]
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ enviroment variables:
   ratelimiting information will be removed
 - `CLIENT_REAP_INTERVAL` (in seconds; defaults to 10 minutes) changes the
   interval at which ratelimiting information will be checked for decay
-- `METRIC_TIMEOUT` (in seconds; defaults to 5 minutes) ccontrols how long
+- `METRIC_TIMEOUT` (in seconds; defaults to 5 minutes) controls how long
   metrics (metrics are identified by their combination of http method + route +
   response code + rate limit scope) will continue to be reported past their last
   occurence before they are discarded. This avoids polluting your metrics with

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ enviroment variables:
   ratelimiting information will be removed
 - `CLIENT_REAP_INTERVAL` (in seconds; defaults to 10 minutes) changes the
   interval at which ratelimiting information will be checked for decay
+- `METRIC_TIMEOUT` (in seconds; defaults to 5 minutes) controls how long
+  metrics will continue to be reported past their last usage.
 
 ### Running via Docker
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ enviroment variables:
   ratelimiting information will be removed
 - `CLIENT_REAP_INTERVAL` (in seconds; defaults to 10 minutes) changes the
   interval at which ratelimiting information will be checked for decay
-- `METRIC_TIMEOUT` (in seconds; defaults to 5 minutes) controls how long
-  metrics will continue to be reported past their last usage.
+- `METRIC_TIMEOUT` (in seconds; defaults to 5 minutes) ccontrols how long
+  metrics (metrics are identified by their combination of http method + route +
+  response code + rate limit scope) will continue to be reported past their last
+  occurence before they are discarded. This avoids polluting your metrics with
+  one off request metrics (9 datapoints per scrape) for long after it happened
 
 ### Running via Docker
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ enviroment variables:
   interval at which ratelimiting information will be checked for decay
 - `METRIC_TIMEOUT` (in seconds; defaults to 5 minutes) controls how long
   metrics (metrics are identified by their combination of http method + route +
-  response code + rate limit scope) will continue to be reported past their last
+  response code + ratelimit scope) will continue to be reported past their last
   occurence before they are discarded. This avoids polluting your metrics with
   one off request metrics (9 datapoints per scrape) for long after it happened
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ use lazy_static::lazy_static;
 use metrics::histogram;
 #[cfg(feature = "expose-metrics")]
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+#[cfg(feature = "expose-metrics")]
+use metrics_util::MetricKindMask;
+#[cfg(feature = "expose-metrics")]
+use std::time::Duration;
 
 #[cfg(feature = "expose-metrics")]
 lazy_static! {
@@ -85,7 +89,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     #[cfg(feature = "expose-metrics")]
     {
-        let recorder = PrometheusBuilder::new().build_recorder();
+        let recorder = PrometheusBuilder::new()
+            .idle_timeout(
+                MetricKindMask::COUNTER | MetricKindMask::HISTOGRAM,
+                Some(Duration::from_secs(120)),
+            )
+            .build_recorder();
         handle = Arc::new(recorder.handle());
         metrics::set_boxed_recorder(Box::new(recorder))
             .expect("Failed to create metrics receiver!");

--- a/src/ratelimiter_map.rs
+++ b/src/ratelimiter_map.rs
@@ -1,31 +1,16 @@
 use dashmap::{mapref::multiple::RefMulti, DashMap};
-use std::{env, str::FromStr, sync::Arc};
+use std::sync::Arc;
 use tokio::time::{interval, Duration, Instant};
-use tracing::{debug, warn};
+use tracing::debug;
 use twilight_http_ratelimiting::InMemoryRatelimiter;
+
+use crate::parse_env;
 
 pub struct RatelimiterMap {
     default: InMemoryRatelimiter,
     default_token: String,
     max_size: Option<usize>,
     inner: Arc<DashMap<String, (InMemoryRatelimiter, Instant)>>,
-}
-
-fn parse_env<T: FromStr>(key: &str) -> Option<T> {
-    env::var_os(key).and_then(|value| match value.into_string() {
-        Ok(s) => {
-            if let Ok(t) = s.parse() {
-                Some(t)
-            } else {
-                warn!("Unable to parse {}, proceeding with defaults", key);
-                None
-            }
-        }
-        Err(s) => {
-            warn!("{} is not UTF-8: {:?}", key, s);
-            None
-        }
-    })
 }
 
 async fn reap_old_ratelimiters(map: Arc<DashMap<String, (InMemoryRatelimiter, Instant)>>) {


### PR DESCRIPTION
Currently metrics don't timeout and any combination of http verb + endpoint + statuscode + ratelimit scope is kept once observed until the proxy is restarted. Each of these results in 9 additional datapoints per scrape.

This builds up very quickly in prometheus, especially if you hit a very exceptional case and don't reboot your proxy often (like a 503 or even 409). With this timeout these metrics will stop being reported after the combination has not been observed for 2 minutes.

An added bonus is cleaner graphs in dashboards downstream because there will not be an entry for combinations not observed to filter out of the timeframe